### PR TITLE
Update SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,24 @@ const bynn = Bynn({
       return;
     }
     console.log('Verification started:', response);
+  },
+  onStart: (sessionId) => {
+    console.log('Verification started:', sessionId);
+  },
+  onComplete: (sessionId) => {
+    console.log('Verification completed:', sessionId);
+  },
+  onError: (sessionId, error) => {
+    console.error('Verification error:', error);
+  },
+  onReject: (sessionId) => {
+    console.log('Verification rejected:', sessionId);
+  },
+  onSuccess: (sessionId) => {
+    console.log('Verification successful:', sessionId);
+  },
+  onClose: () => {
+    console.log('Verification closed');
   }
 });
 ```
@@ -209,7 +227,6 @@ You can also style specific elements using these CSS classes:
 - `.bynn-modal-overlay` - Verification modal overlay
 - `.bynn-modal-container` - Modal container
 - `.bynn-modal-content` - Modal content
-- `.bynn-modal-close` - Modal close button
 
 Example custom styles:
 
@@ -252,7 +269,14 @@ const bynn = Bynn({
 | `parentId` | string | Yes | ID of container element |
 | `fields` | Field[] | No | Form field configuration |
 | `i18n` | string | No | Language code |
+| `startTimeoutSeconds` | number   | No | Timeout in seconds to wait for verification start (default 10 seconds) |
 | `onSession` | function | No | Session callback |
+| `onStart` | function | No | Start callback                                                         |
+| `onComplete` | function | No | Complete callback                                                      |
+| `onError` | function | No | Error callback                                                         |
+| `onReject` | function | No | Reject callback                                                        |
+| `onSuccess` | function | No | Success callback                                                       |
+| `onClose` | function | No | Close callback                                                         |
 
 ### Field Configuration
 

--- a/example.html
+++ b/example.html
@@ -37,9 +37,6 @@
                 console.log('Verification onSession id:', response.sessionId);
             }
         },
-        onTimeout: (sessionId) => {
-            console.log('Verification timed out, session id:', sessionId);
-        },
         onCancel: () => {
             console.log('Verification canceled');
         },
@@ -51,9 +48,16 @@
         },
         onStart: (sessionId) => {
             console.log('Verification started, session id:', sessionId);
+        },
+        onReject: (sessionId) => {
+            console.log('Verification rejected, session id:', sessionId);
+        },
+        onSuccess: (sessionId) => {
+            console.log('Verification successful, session id:', sessionId);
+        },
+        onClose: () => {
+            console.log('Verification closed');
         }
-
-
     });
 
     bynn.mount({

--- a/examples/example.html
+++ b/examples/example.html
@@ -34,6 +34,24 @@
                 if (response) {
                     console.log('Verification response:', response);
                 }
+            },
+            onStart: (sessionId) => {
+                console.log('Verification started:', sessionId);
+            },
+            onComplete: (sessionId) => {
+                console.log('Verification completed:', sessionId);
+            },
+            onError: (sessionId, error) => {
+                console.error('Verification error:', error);
+            },
+            onReject: (sessionId) => {
+                console.log('Verification rejected:', sessionId);
+            },
+            onSuccess: (sessionId) => {
+                console.log('Verification successful:', sessionId);
+            },
+            onClose: () => {
+                console.log('Verification closed');
             }
         });
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -18,11 +18,12 @@ function createBynn(config: BynnConfig): BynnSDK {
     onSession,
     i18n,
     kycLevel,
-    onTimeout,
     onCancel,
     onComplete,
     onError,
-    onStart
+    onStart,
+    onReject,
+    onSuccess
   } = config;
 
   let params: BynnParams = {
@@ -81,18 +82,19 @@ function createBynn(config: BynnConfig): BynnSDK {
         // Create a configuration object with all the callbacks
         const modalConfig = {
           ...config,
-          onTimeout,
           onCancel,
           onComplete,
           onError,
-          onStart
+          onStart,
+          onReject,
+          onSuccess
         };
 
         // Show modal with all necessary callbacks
-        showVerificationModal(response.url, response.session_id, modalConfig);
+        showVerificationModal(response.url, response.sessionId, modalConfig);
 
         if (onSession) {
-          onSession(null, response, response.session_id);
+          onSession(null, response, response.sessionId);
         }
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : 'An unexpected error occurred';

--- a/src/styles/modal.css
+++ b/src/styles/modal.css
@@ -28,20 +28,3 @@
   padding: 1.5rem;
   overflow: hidden;
 }
-
-.bynn-modal-close {
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  width: 32px;
-  height: 32px;
-  background: white;
-  border: none;
-  border-radius: 50%;
-  cursor: pointer;
-  z-index: 1000000;
-  color: #1F2937;
-}
-
-
-

--- a/src/styles/modal.css
+++ b/src/styles/modal.css
@@ -11,6 +11,7 @@
   padding: 2rem;
   z-index: 999999;
   backdrop-filter: blur(8px);
+  cursor: pointer;
 }
 
 .bynn-modal-container {

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,11 +23,14 @@ export interface BynnConfig {
     i18n?: string;
     fields?: FormField[];
     onSession?: (error: Error | null, response: SessionResponse | null, sessionId?: string) => void;
-    onTimeout?: (sessionId: string) => void;
     onCancel?: (sessionId: string) => void;
     onComplete?: (sessionId: string) => void;
     onError?: (sessionId: string, error: string | Error) => void;
     onStart?: (sessionId: string) => void;
+    startTimeoutSeconds?: number;
+    onReject?: (sessionId: string) => void;
+    onSuccess?: (sessionId: string) => void;
+    onClose?: () => void;
 }
 
 export interface FormOptions {
@@ -69,7 +72,14 @@ export interface BynnSDK {
     mount: (options?: FormOptions) => void;
 }
 
-export type VerificationStatus = 'timeout' | 'cancel' | 'complete' | 'error' | 'start';
+export type VerificationStatus =
+  | 'timeout'
+  | 'cancel'
+  | 'completed'
+  | 'error'
+  | 'start'
+  | 'rejected'
+  | 'successful';
 
 export interface VerificationMessage {
     type: 'bynn-verification';

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,11 +60,6 @@ export interface ApiError {
     };
 }
 
-export interface IframeOptions {
-    width?: string;
-    height?: string;
-    className?: string;
-}
 
 export interface BynnSDK {
     params: BynnParams;

--- a/src/ui/alerts/error-modal.ts
+++ b/src/ui/alerts/error-modal.ts
@@ -3,9 +3,9 @@ import { createModal } from '../modal/modal';
 import { createElement } from '../../utils/dom';
 
 export function showErrorModal(message: string): void {
-  const modal = createModal();
-  const content = modal.querySelector('.bynn-modal-content');
-  
+  const { modalElement } = createModal();
+  const content = modalElement.querySelector('.bynn-modal-content');
+
   if (content) {
     const alert = createElement('div', 'bynn-error-alert');
     alert.setAttribute('style', `
@@ -24,6 +24,6 @@ export function showErrorModal(message: string): void {
     alert.appendChild(text);
     content.appendChild(alert);
   }
-  
-  document.body.appendChild(modal);
+
+  document.body.appendChild(modalElement);
 }

--- a/src/ui/iframe.ts
+++ b/src/ui/iframe.ts
@@ -1,7 +1,6 @@
-import { IframeOptions } from '../types';
 import { createElement } from '../utils/dom';
 
-export function createVerificationIframe(url: string, options: IframeOptions = {}): HTMLIFrameElement {
+export function createVerificationIframe(url: string, options ): HTMLIFrameElement {
   const {
     width = '100%',
     height = '600px',

--- a/src/ui/modal/modal.ts
+++ b/src/ui/modal/modal.ts
@@ -1,7 +1,10 @@
 import '../../styles/modal.css';
 import { createElement } from '../../utils/dom';
 
-export function createModal(): HTMLDivElement {
+export function createModal(): {
+  modalElement: HTMLDivElement;
+  closeModal: () => void;
+} {
   // Create overlay
   const overlay = createElement('div', 'bynn-modal-overlay');
 
@@ -11,20 +14,36 @@ export function createModal(): HTMLDivElement {
   // Create content wrapper
   const content = createElement('div', 'bynn-modal-content');
 
-  // Create close button
-  const closeButton = createElement('button', 'bynn-modal-close', {
-    innerHTML: '×',
-    onclick: () => {
-      overlay.remove();
-      document.body.style.overflow = 'auto';
-    }
-  });
-
   // Prevent body scroll when modal is open
   document.body.style.overflow = 'hidden';
 
-  container.append(closeButton, content);
+  overlay.style.cursor = 'pointer';
+
+  container.style.cursor = 'default';
+
+  container.append(content);
   overlay.appendChild(container);
 
-  return overlay;
+  let clickHandler: ((event: MouseEvent) => void) | null = null;
+
+  const closeModal = () => {
+    if (clickHandler) {
+      overlay.removeEventListener('click', clickHandler);
+      clickHandler = null;
+    }
+
+    overlay.remove();
+
+    document.body.style.overflow = '';
+  };
+
+  clickHandler = (event: MouseEvent) => {
+    if (event.target === overlay) {
+      closeModal();
+    }
+  };
+
+  overlay.addEventListener('click', clickHandler);
+
+  return { modalElement: overlay, closeModal };
 }

--- a/src/ui/modal/modal.ts
+++ b/src/ui/modal/modal.ts
@@ -17,10 +17,6 @@ export function createModal(): {
   // Prevent body scroll when modal is open
   document.body.style.overflow = 'hidden';
 
-  overlay.style.cursor = 'pointer';
-
-  container.style.cursor = 'default';
-
   container.append(content);
   overlay.appendChild(container);
 

--- a/src/ui/verification-modal.ts
+++ b/src/ui/verification-modal.ts
@@ -1,4 +1,4 @@
-import { IframeOptions, BynnConfig, VerificationMessage } from '../types';
+import { BynnConfig, VerificationMessage } from '../types';
 import { createModal } from './modal/modal';
 import { createElement } from '../utils/dom';
 import { applyStyles } from '../utils/styles';
@@ -9,7 +9,6 @@ export function showVerificationModal(
     url: string,
     sessionId: string,
     config: BynnConfig,
-    iframeOptions: IframeOptions = {}
 ): void {
   const { modalElement, closeModal } = createModal();
   const content = modalElement.querySelector('.bynn-modal-content');


### PR DESCRIPTION
### New signals:
* Added support for new callbacks (`onReject`, `onSuccess`, `onClose`) in the `createBynn` function. Removed the `onTimeout` callback and updated the `VerificationStatus` type to include new statuses like `rejected` and `successful`. [[1]](diffhunk://#diff-033ecd338eec0994fe53c0896219baee901e20068b8fbe6259a23d5759584b06L21-R26) [[2]](diffhunk://#diff-033ecd338eec0994fe53c0896219baee901e20068b8fbe6259a23d5759584b06L84-R112) [[3]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aL72-R86)
* Added new callback options (`onReject`, `onSuccess`, `onClose`) to the SDK configuration and updated the README to reflect these changes. Also added a new `startTimeoutSeconds` configuration option. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R179-R196) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L250-R293) [[3]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aL25-R37)
*  Added support for new callbacks (`onReject`, `onSuccess`, `onClose`) in the example implementation. [[1]](diffhunk://#diff-944b383bb2910b5301b84156da46bc95bd52de198c88f7ef25b45b0659943802L40-L56) [[2]](diffhunk://#diff-c82ae7c50264c132eafa97263aedf7a43c957977ee97eb7c2ed78839b79679f3R40-R57)

### Closing modal by timeout and by click outside:
- Updated `createModal` function to return an object containing the modal element and a close function.
- Added `startTimeoutSeconds` option to `BynnConfig` for configurable timeout duration.
- Modified `showVerificationModal` and `showErrorModal` to use the new modal structure and handle timeout logic.
- Updated README to reflect changes in configuration options.

### Remove SDK close button
- Removed the `.bynn-modal-close` CSS class and related styles.